### PR TITLE
Renamer bugfix

### DIFF
--- a/jdd_outlinerBuddy.py
+++ b/jdd_outlinerBuddy.py
@@ -489,7 +489,7 @@ class buddyOutl_Window(object):
         return self.baseCQ
     def setPrefixCheck(self, *args):
         self.prefixCQ = cmds.checkBox(self.prefixCheck, query = True, v = True)
-        return str(self.prefixCQ)
+        return self.prefixCQ
     def setReplaceFirstCheck(self, *args):
         self.replaceFirstCQ = cmds.checkBox(self.replaceFirstCheck, query = True, v = True)
         return self.replaceFirstCQ

--- a/jdd_outlinerBuddy.py
+++ b/jdd_outlinerBuddy.py
@@ -622,7 +622,7 @@ class buddyOutl_Window(object):
                         if self.setBaseCheck() == False and self.setSuffixCheck() == False:
                             newName = str(namePrefix) + str(nameBase) + str(nameSuffix)
                         else:
-                            newName = str(namePrefix) + str(nameBase) + str(nameSuffix) + str(self.zeroPad(nameInc, namePad))
+                            newName = str(namePrefix) + str(nameBase) + str(self.zeroPad(nameInc, namePad)) + str(nameSuffix)
                             nameInc += nameStep
                     else:
                         newName = str(namePrefix) + str(nameBase) + str(nameSuffix)

--- a/jdd_outlinerBuddy.py
+++ b/jdd_outlinerBuddy.py
@@ -595,28 +595,32 @@ class buddyOutl_Window(object):
             namePad = 0
         
         for i in self.funcSort(self.selectionMethod, 1):
-            if self.setBaseCheck() == True:
-                nameBase = self.updateBaseInput()
-            else:
-                if '|' in i:
-                    nameShort = i.split('|')[-1]
-                    nameBaseRF = nameShort[repF::]
-                    nameBaseRF = nameBaseRF[::-1]
-                    nameBaseRL = nameBaseRF[repL::]
-                    nameBase = nameBaseRL[::-1]
+            try:
+                if self.setBaseCheck() == True:
+                    nameBase = self.updateBaseInput()
                 else:
-                    nameBase = i
+                    if '|' in i:
+                        nameShort = i.split('|')[-1]
+                        nameBaseRF = nameShort[repF::]
+                        nameBaseRF = nameBaseRF[::-1]
+                        nameBaseRL = nameBaseRF[repL::]
+                        nameBase = nameBaseRL[::-1]
+                    else:
+                        nameBase = i
 
-            if self.setIncCheck() == True:
-                if self.setBaseCheck() == False and self.setSuffixCheck() == False:
-                    newName = str(namePrefix) + str(nameBase) + str(nameSuffix)
+                if self.setIncCheck() == True:
+                    if self.setBaseCheck() == False and self.setSuffixCheck() == False:
+                        newName = str(namePrefix) + str(nameBase) + str(nameSuffix)
+                    else:
+                        newName = str(namePrefix) + str(nameBase) + str(nameSuffix) + str(self.zeroPad(nameInc, namePad))
+                        nameInc += nameStep
                 else:
-                    newName = str(namePrefix) + str(nameBase) + str(nameSuffix) + str(self.zeroPad(nameInc, namePad))
-                    nameInc += nameStep
-            else:
-                newName = str(namePrefix) + str(nameBase) + str(nameSuffix)
-            operationCount += 1     
-            cmds.rename(i, newName)
+                    newName = str(namePrefix) + str(nameBase) + str(nameSuffix)
+                operationCount += 1
+                print(namePrefix)
+                cmds.rename(i, newName)
+            except RuntimeError:
+                self.renameText()
             #if '|' in i:
             #    namePath = cmds.listRelatives(f=1, s=0)
             #    namePath=''.join(namePath)

--- a/jdd_outlinerBuddy.py
+++ b/jdd_outlinerBuddy.py
@@ -554,105 +554,108 @@ class buddyOutl_Window(object):
     
     #-----Rename-----#
     def renameText(self, *args):
-        operationCount = 0
         
-        #Pre/Suffix
-        if self.setPrefixCheck() == True:
-            namePrefix = self.updatePrefixInput()
-        else:
-            namePrefix = ''
-        
-        if self.setSuffixCheck() == True:
-            nameSuffix = self.updateSuffixInput()
-        else:
-            nameSuffix = ''
-        
-        #Replace First/Last
-        if self.setReplaceFirstCheck() == True:
-            repF = self.updateReplaceFirstInput()
-        else:
-            repF = 0
+        def runRenameText(op=0):
+            operationCount = op
+            #Pre/Suffix
+            if self.setPrefixCheck() == True:
+                namePrefix = self.updatePrefixInput()
+            else:
+                namePrefix = ''
 
-        if self.setReplaceLastCheck() == True:
-            repL = self.updateReplaceLastInput()
-        else:
-            repL = 0
+            if self.setSuffixCheck() == True:
+                nameSuffix = self.updateSuffixInput()
+            else:
+                nameSuffix = ''
 
-        #Increment
-        if self.setIncCheck() == True:
-            nameInc = self.updateStartInput()
-        else:
-            nameInc = ''
+            #Replace First/Last
+            if self.setReplaceFirstCheck() == True:
+                repF = self.updateReplaceFirstInput()
+            else:
+                repF = 0
 
-        if self.setStepCheck() == True:
-            nameStep = self.updateStepInput()
-        else:
-            nameStep = 1
-        
-        if self.setPaddingCheck() == True:
-            namePad = self.updatePaddingInput()
-        else:
-            namePad = 0
-        
-        for i in self.funcSort(self.selectionMethod, 1):
-            try:
-                if self.setBaseCheck() == True:
-                    nameBase = self.updateBaseInput()
-                else:
-                    if '|' in i:
-                        nameShort = i.split('|')[-1]
-                        nameBaseRF = nameShort[repF::]
-                        nameBaseRF = nameBaseRF[::-1]
-                        nameBaseRL = nameBaseRF[repL::]
-                        nameBase = nameBaseRL[::-1]
+            if self.setReplaceLastCheck() == True:
+                repL = self.updateReplaceLastInput()
+            else:
+                repL = 0
+
+            #Increment
+            if self.setIncCheck() == True:
+                nameInc = self.updateStartInput()
+            else:
+                nameInc = ''
+
+            if self.setStepCheck() == True:
+                nameStep = self.updateStepInput()
+            else:
+                nameStep = 1
+
+            if self.setPaddingCheck() == True:
+                namePad = self.updatePaddingInput()
+            else:
+                namePad = 0
+
+            for i in self.funcSort(self.selectionMethod, 1):
+                try:
+                    if self.setBaseCheck() == True:
+                        nameBase = self.updateBaseInput()
                     else:
-                        nameBase = i
+                        if '|' in i:
+                            nameShort = i.split('|')[-1]
+                            nameBaseRF = nameShort[repF::]
+                            nameBaseRF = nameBaseRF[::-1]
+                            nameBaseRL = nameBaseRF[repL::]
+                            nameBase = nameBaseRL[::-1]
+                        else:
+                            nameBase = i
 
-                if self.setIncCheck() == True:
-                    if self.setBaseCheck() == False and self.setSuffixCheck() == False:
+                    if self.setIncCheck() == True:
+                        if self.setBaseCheck() == False and self.setSuffixCheck() == False:
+                            newName = str(namePrefix) + str(nameBase) + str(nameSuffix)
+                        else:
+                            newName = str(namePrefix) + str(nameBase) + str(nameSuffix) + str(self.zeroPad(nameInc, namePad))
+                            nameInc += nameStep
+                    else:
                         newName = str(namePrefix) + str(nameBase) + str(nameSuffix)
-                    else:
-                        newName = str(namePrefix) + str(nameBase) + str(nameSuffix) + str(self.zeroPad(nameInc, namePad))
-                        nameInc += nameStep
-                else:
-                    newName = str(namePrefix) + str(nameBase) + str(nameSuffix)
-                operationCount += 1
-                print(namePrefix)
-                cmds.rename(i, newName)
-            except RuntimeError:
-                self.renameText()
-            #if '|' in i:
-            #    namePath = cmds.listRelatives(f=1, s=0)
-            #    namePath=''.join(namePath)
-            #    namePath=namePath.split('|')
-            #    namePathLength = len(namePath)
-            #    namePath = "|".join(namePath[:namePathLength-1])
-            #    k = '|' + i
-            #    #currentName = cmds.ls(i, long=True)
-            #    #currentName = currentName[0]
-            #    #iL = len(i)
-            #    #pL = len(currentName)
-            #    #fL = pL-iL
-            #    #target = currentName[:fL]
-            #    endName = namePath + '|' + newName
-            #    cmds.rename(k, endName)
-            #else:
-            #    cmds.rename(i, newName)
-            #try:
-            #    cmds.rename(i, newName)
-            #except RuntimeError:
-            #    try:
-            #        currentName = cmds.listRelatives(fullPath=True)
-            #        namePath = currentName.split('|')
-            #        l=len(namePath)
-            #        l-=1
-            #        currentName=namePath[:l].join('|')
-            #
-            #        endName = currentName + newName
-            #        cmds.rename(i, endName)
-            #    except:
-            #        continue
+                    operationCount += 1
+                    cmds.rename(i, newName)
+                except RuntimeError:
+                    runRenameText(operationCount)
                 
+            return operationCount
+        operationCount = runRenameText()
+        runRenameText()
+        #if '|' in i:
+        #    namePath = cmds.listRelatives(f=1, s=0)
+        #    namePath=''.join(namePath)
+        #    namePath=namePath.split('|')
+        #    namePathLength = len(namePath)
+        #    namePath = "|".join(namePath[:namePathLength-1])
+        #    k = '|' + i
+        #    #currentName = cmds.ls(i, long=True)
+        #    #currentName = currentName[0]
+        #    #iL = len(i)
+        #    #pL = len(currentName)
+        #    #fL = pL-iL
+        #    #target = currentName[:fL]
+        #    endName = namePath + '|' + newName
+        #    cmds.rename(k, endName)
+        #else:
+        #    cmds.rename(i, newName)
+        #try:
+        #    cmds.rename(i, newName)
+        #except RuntimeError:
+        #    try:
+        #        currentName = cmds.listRelatives(fullPath=True)
+        #        namePath = currentName.split('|')
+        #        l=len(namePath)
+        #        l-=1
+        #        currentName=namePath[:l].join('|')
+        #
+        #        endName = currentName + newName
+        #        cmds.rename(i, endName)
+        #    except:
+        #        continue
                 
         if operationCount > 0:
             print("Renamed " + str(operationCount) + " object(s).")

--- a/jdd_outlinerBuddy.py
+++ b/jdd_outlinerBuddy.py
@@ -243,43 +243,6 @@ class buddyOutl_Window(object):
         z = '0' * y + str(num)
         return z
     
-    #def cutPathName(self, name, x='|'):
-    #    wordLength = len(name)
-    #    try:
-    #        nameIndex = name[::-1].index(x)
-    #    except:
-    #        nameIndex = wordLength
-    #
-    #    res = wordLength - nameIndex
-    #    return res
-
-    #def shortName(self, name, x='|'):
-    #    nameIndex = self.cutPathName(name, x)
-    #    res = name[nameIndex:]
-    #    return res
-
-    #def fullName(self, name, isNameNew=False, newName='', x='|'):
-    #    nameIndex = self.cutPathName(name, x)
-    #    if isNameNew == False:
-    #        shortName = self.shortName(name)
-    #    else:
-    #        shortName = newName
-    #    
-    #    partialName = str(name[:nameIndex])
-    #    
-    #    res = partialName + shortName
-    #    return res
-
-    def shorten(self, name, x='|'):
-        wordLength = len(name)
-        try:
-            nameIndex = name[::-1].index(x)
-        except:
-            nameIndex = wordLength
-
-        nameIndex = wordLength - nameIndex
-        return name[:nameIndex]
-    
     def quickAdd(self, x, isPrefix, separator='_'):
         operationCount = 0
         for i in self.funcSort(self.selectionMethod, 1):

--- a/jdd_outlinerBuddy.py
+++ b/jdd_outlinerBuddy.py
@@ -555,7 +555,7 @@ class buddyOutl_Window(object):
     #-----Rename-----#
     def renameText(self, *args):
         
-        def runRenameText(op=0, cl=['']):
+        def runRenameText(op=0, cl=[]):
             operationCount = op
             #Pre/Suffix
             if self.setPrefixCheck() == True:
@@ -597,19 +597,17 @@ class buddyOutl_Window(object):
 
             selectionList = self.funcSort(self.selectionMethod, 1)
             completedList = cl
-
-            if '' not in completedList:
+            if len(cl) > 0:
                 for i in completedList:
-                    currentList = selectionList.remove(i)
-            else:
-                currentList = selectionList
+                    print ('Removing.....'+ i)
+                    selectionList.remove(i)
             
-            for i in currentList:
+            for i in selectionList:
                 try:
                     if self.setBaseCheck() == True:
                         nameBase = self.updateBaseInput()
                     else:
-                        if '|' in i:
+                        if '|' in i: #Separate duplicate from parents
                             nameBase = i.split('|')[-1]
                         else:
                             nameBase = i
@@ -626,11 +624,12 @@ class buddyOutl_Window(object):
                             nameInc += nameStep
                     else:
                         newName = str(namePrefix) + str(nameBase) + str(nameSuffix)
+                    
                     operationCount += 1
                     cmds.rename(i, newName)
                     completedList = completedList + [newName]
                 except RuntimeError:
-                    runRenameText(operationCount)
+                    runRenameText(operationCount, completedList)
                 
             return operationCount
         

--- a/jdd_outlinerBuddy.py
+++ b/jdd_outlinerBuddy.py
@@ -555,7 +555,7 @@ class buddyOutl_Window(object):
     #-----Rename-----#
     def renameText(self, *args):
         
-        def runRenameText(op=0):
+        def runRenameText(op=0, cl=['']):
             operationCount = op
             #Pre/Suffix
             if self.setPrefixCheck() == True:
@@ -595,7 +595,16 @@ class buddyOutl_Window(object):
             else:
                 namePad = 0
 
-            for i in self.funcSort(self.selectionMethod, 1):
+            selectionList = self.funcSort(self.selectionMethod, 1)
+            completedList = cl
+
+            if '' not in completedList:
+                for i in completedList:
+                    currentList = selectionList.remove(i)
+            else:
+                currentList = selectionList
+            
+            for i in currentList:
                 try:
                     if self.setBaseCheck() == True:
                         nameBase = self.updateBaseInput()
@@ -619,12 +628,14 @@ class buddyOutl_Window(object):
                         newName = str(namePrefix) + str(nameBase) + str(nameSuffix)
                     operationCount += 1
                     cmds.rename(i, newName)
+                    completedList = completedList + [newName]
                 except RuntimeError:
                     runRenameText(operationCount)
                 
             return operationCount
+        
         operationCount = runRenameText()
-        runRenameText()
+
         #if '|' in i:
         #    namePath = cmds.listRelatives(f=1, s=0)
         #    namePath=''.join(namePath)

--- a/jdd_outlinerBuddy.py
+++ b/jdd_outlinerBuddy.py
@@ -601,13 +601,13 @@ class buddyOutl_Window(object):
                         nameBase = self.updateBaseInput()
                     else:
                         if '|' in i:
-                            nameShort = i.split('|')[-1]
-                            nameBaseRF = nameShort[repF::]
-                            nameBaseRF = nameBaseRF[::-1]
-                            nameBaseRL = nameBaseRF[repL::]
-                            nameBase = nameBaseRL[::-1]
+                            nameBase = i.split('|')[-1]
                         else:
                             nameBase = i
+                        nameBaseRF = nameBase[repF::]
+                        nameBaseRF = nameBaseRF[::-1]
+                        nameBaseRL = nameBaseRF[repL::]
+                        nameBase = nameBaseRL[::-1]
 
                     if self.setIncCheck() == True:
                         if self.setBaseCheck() == False and self.setSuffixCheck() == False:

--- a/jdd_outlinerBuddy.py
+++ b/jdd_outlinerBuddy.py
@@ -599,7 +599,6 @@ class buddyOutl_Window(object):
             completedList = cl
             if len(cl) > 0:
                 for i in completedList:
-                    print ('Removing.....'+ i)
                     selectionList.remove(i)
             
             for i in selectionList:


### PR DESCRIPTION
Bugfixes related to the renaming tool's behavior:
- Added exception to rerun command when command breaks
- Added completed list to avoid renaming objects twice
- Fixed Maya crashing if renaming duplicates while base name is turned off
- Repositioned incrementation position in name from **prefix_base_suffix_increment** to **prefix_base_increment_suffix**
- Moved old code to comments just in case

General hotfixes:
- Simplified `selectionStatus()`
- Simplified `nameShort` code
- Removed obsolete `self.selectionMethod()`
- Removed `shorten()` and related older code in comments