### PR TITLE
v1.1.1: More errors and fixed lonely objects bug

### DIFF
--- a/jdd_outlinerBuddy.py
+++ b/jdd_outlinerBuddy.py
@@ -727,9 +727,11 @@ class buddyOutl_Window(object):
         if remOrder == 'first':
             remF = self.updateRemoveFirstInput()
             remL = 0
-        else:
+        elif remOrder == 'last':
             remF = 0
             remL = self.updateRemoveLastInput()
+        else:
+            raise ValueError("The argument used in self.quickRemove() should either be \"first\" or \"last\".")
 
         removeAmount = remF + remL
         selectionList = self.funcSort(self.selectionMethod, 1)
@@ -750,27 +752,19 @@ class buddyOutl_Window(object):
                 failureCount += 1
                 failureList += cmds.ls(a, sn = True)
                 continue
-        return operationCount, failureCount, failureList, removeAmount
-    
-    def removeFirst(self, *args):
-        operationCount, failureCount, failureList, removeAmount = self.quickRemove('first')
         
         if operationCount > 0:
-            print("Removed first " + str(removeAmount) + " character(s) on " + str(operationCount) + " object(s)")
+            print("Removed " + remOrder + " " + str(removeAmount) + " character(s) on " + str(operationCount) + " object(s)")
         elif failureCount > 0:
             print("# ValueError: Unable to remove anymore characters from " + str(failureCount) + " object(s)" + 
             "\n# Failed operations: " + str(failureList) +
-            "# ValueError: Unable to remove anymore characters from " + str(failureCount) + " object(s)")
+            "\n# ValueError: Unable to remove anymore characters from " + str(failureCount) + " object(s)")
+    
+    def removeFirst(self, *args):
+        self.quickRemove('first')
     
     def removeLast(self, *args):
-        operationCount, failureCount, failureList, removeAmount = self.quickRemove('last')
-
-        if operationCount > 0:
-            print("Removed last " + str(removeAmount) + " character(s) on " + str(operationCount) + " object(s)")
-        elif failureCount > 0:
-            print("# ValueError: Unable to remove anymore characters from " + str(failureCount) + " object(s)" + 
-            "\n# Failed operations: " + str(failureList) +
-            "# ValueError: Unable to remove anymore characters from " + str(failureCount) + " object(s)")
+        self.quickRemove('last')
     
     def removeSelected(self, *args):
         if self.setRemovePastedCheck() == True:

--- a/jdd_outlinerBuddy.py
+++ b/jdd_outlinerBuddy.py
@@ -1,7 +1,7 @@
 #-----------------------------Tested for Maya 2022+-----------------------------#
 #
 #             jdd_outlinerBuddy.py 
-#             v1.0.1, last modified 21/06/2022
+#             v1.1.1, last modified 08/07/22
 # 
 # MIT License
 # Copyright (c) 2020 Jordan Dion-Duval
@@ -25,15 +25,17 @@
 # SOFTWARE.
 # 
 #----------------------------------INSTALLATION---------------------------------#
-# Copy the "jdd_outlinerBuddy.py" to your Maya scripts directory:
-#     MyDocuments\Maya\scripts\
-#         use this text as a python script within Maya:
+# 1. Copy the "jdd_outlinerBuddy.py" to your Maya scripts directory:
+#     > MyDocuments\Maya\scripts\
+# 2. Then, within maya, use the following text as a python script to run the tool:
+#    (without the apostrophes)
 '''
 import jdd_outlinerBuddy as OB
 OB.UI()
 '''
-# this text can be entered from the script editor and can be made into a button
-#
+# 3.(Optional) Alternatively, the text can be saved in the custom shelf using
+# maya's script editor. This makes the script a small button in your current shelf
+# so it can easily be accessed later.
 #--------------------------------------------------------------------------------#
 import maya.cmds as cmds
 

--- a/jdd_outlinerBuddy.py
+++ b/jdd_outlinerBuddy.py
@@ -386,8 +386,12 @@ class buddyOutl_Window(object):
             print("# ValueError\n# Failed operations (" + str(illegalCount) + "): " + str(failureList))
             raise ValueError("Resulting object names would start with an illegal character")
         if failureCount > 0:
-            print("# ValueError\n# Failed operations (" + str(failureCount) + "): " + str(failureList))
-            raise ValueError("Could not find search name in target objects")
+            if operationCount > 0:
+                print("# Warning\n# Failed operations (" + str(failureCount) + "): " + str(failureList))
+                raise Warning("Could not find search name from certain objects in current selection")
+            else:
+                print("# ValueError\n# Failed operations (" + str(failureCount) + "): " + str(failureList))
+                raise ValueError("Could not find search name in current selection")
     
     def listSl(self):
         res = cmds.ls(sl=True)
@@ -803,10 +807,6 @@ class buddyOutl_Window(object):
         if illegalCount > 0:
             print("# Warning\n# Modified operations(" + str(illegalCount) + "): " + str(illegalList))
             raise Warning("Added \"" + excText + "\" in front of illegal object names")
-            #print("# Warning: Adding \"" + excText + "\" in front of" + str(illegalCount) + " illegal object name(s)" + 
-            #"\n# Names can only start with alphabetical characters (A-Z) or with underscores ( _ )" +
-            #"\n# Object list: " + str(illegalList) +
-            #"\n# Warning: Adding \"" + excText + "\" in front of" + str(illegalCount) + " illegal object name(s)")
         if fixCount > 0:
             print("Removed \"" + excText + "\" from " + fixCount + " object(s) (Object(s) previously had illegal names)")
         if failureCount > 0:


### PR DESCRIPTION
- Simplified removeFirst() and removeLast() code block (both commands now rely on quickRemove())
- Fixed bug that stopped some commands from working when executed on objects with no parents
- Re-structured some code around errors and exceptions
- Fixed success message counting failed attempts as successes
- Added error messages to the main renaming/replacing functions to stop objects with illegal names from occurring
    - Replace errors
        - Value error for illegal resulting names
        - Warning/Value error for partial/complete failure from finding search term in current selection
    - Rename errors
        - Value error if prefix starts with an illegal character
    - Remove errors
        - Value error when no more characters can be removed
        - Warning that adds "char__" in front of object names if the resulting name is illegal